### PR TITLE
Fix answer

### DIFF
--- a/public/c857.json
+++ b/public/c857.json
@@ -838,13 +838,13 @@
          "User authentication",
          "Data verification",
          "Transaction processing",
-         "User authorizing",
+         "User authorization",
          "Application logging",
          "Data validation"
       ],
       "a": [
          "Transaction processing",
-         "User authorizing",
+         "User authentication",
          "Application logging",
          "Data validation"
       ]


### PR DESCRIPTION
the ucertify material shows "User authentication" as the right answer, not "User authorization"
![image](https://user-images.githubusercontent.com/7895237/85242156-d5050900-b403-11ea-9274-a012266ea1f2.png)
